### PR TITLE
Fix the choice of gpg keys

### DIFF
--- a/thunar-gpg-encrypt.sh
+++ b/thunar-gpg-encrypt.sh
@@ -89,11 +89,9 @@ fi
 chooseRecipient () {
 
 	pubkeys="$(gpg --list-public-keys \
-	  | grep -A 1 pub \
-	  | awk '{print $2,$3,$4}' \
-	  | egrep -v "^[[:space:]]*$" \
-	  | awk 'NR%2{printf $1" ";next;}1' \
-	  | awk '{print substr($0,7,8)" "substr($0,1,5)" \""$2,$3,$4"\""}')"
+	  | grep -A 1 "^pub" \
+	  | sed -n -e "s:^pub *\([A-Za-z0-9]\+\)/\([A-F0-9]\+\) .*$:\1 \2:p" -e "s:^uid *\(.*\)$:\"\1\":p" \
+	  | tr '\n' ' ')"
 
 
 	CMD="zenity --list \
@@ -110,11 +108,9 @@ chooseRecipient () {
 chooseSecret () {
 
 	seckeys="$(gpg --list-secret-keys \
-	  | grep -A 1 sec \
-	  | awk '{print $2,$3,$4}' \
-	  | egrep -v "^[[:space:]]*$" \
-	  | awk 'NR%2{printf $1" ";next;}1' \
-	  | awk '{print substr($0,7,8)" "substr($0,1,5)" \""$2,$3,$4"\""}')"
+	  | grep -A 1 "^sec" \
+	  | sed -n -e "s:^sec *\([A-Za-z0-9]\+\)/\([A-F0-9]\+\) .*$:\1 \2:p" -e "s:^uid *\(.*\)$:\"\1\":p" \
+	  | tr '\n' ' ')"
 
 
 	CMD="zenity --list \


### PR DESCRIPTION
GPG keys were not listed correctly, below the original (debug) output:

``` text
$ gpg --list-public-keys | grep -A 1 "^pub"
pub   rsa2048/YYYYYY 2015-02-12 [SC]
uid         [ unknown] yyyyyyy
--
pub   rsa4096/XXXXXX 2012-03-05 [SC] [expires: 2018-02-02]
uid         [ unknown] xxxx xxxx xxxx xxx xxxxxxxxx xxxxxx

$ sh -x ./thunar-gpg-encrypt.sh -f file 
+ getopts :f: i
+ case "${i}" in
+ f=/home/user/Desktop/file
+ getopts :f: i
+ shift 2
+ '[' -z /home/user/Desktop/file ']'
+ command -v gpg
+ command -v pinentry-gtk-2
+ command -v zenity
++ chooseRecipient
+++ gpg --list-public-keys
+++ grep -A 1 pub
+++ awk '{print $2,$3,$4}'
+++ awk '{print substr($0,7,8)" "substr($0,1,5)" \""$2,$3,$4"\""}'
+++ awk 'NR%2{printf $1" ";next;}1'
+++ egrep -v '^[[:space:]]*$'
++ pubkeys='8/YYYYYY rsa20 "[ unknown] yyyyy"
6/XXXXXX rsa40 "[ unknown] xxxx"'
++ CMD='zenity --list          --width=550 --height=250            --title="GPG Encrypt File for..."           --print-column=1            --text="Choose Recipient"           --column="Key" --column="Bit" --column="Recipient" 8/YYYYYY rsa20 "[ unknown] yyyyyy"
6/XXXXXX rsa40 "[ unknown] xxxx"'
++ eval 'zenity --list         --width=550 --height=250            --title="GPG Encrypt File for..."           --print-column=1            --text="Choose Recipient"           --column="Key" --column="Bit" --column="Recipient" 8/BE8601 rsa20 "[ unknown] yyyyyy"
6/XXXXXX rsa40 "[ unknown] xxxx"'
+++ zenity --list --width=550 --height=250 '--title=GPG Encrypt File for...' --print-column=1 '--text=Choose Recipient' --column=Key --column=Bit --column=Recipient 8/YYYYYY rsa20 '[ unknown] yyyyyy'
Gtk-Message: GtkDialog mapped without a transient parent. This is discouraged.
+++ 6/XXXXXX rsa40 '[ unknown] xxxx'
./thunar-gpg-encrypt.sh: line 107: 6/XXXXXX: No such file or directory
```

I fixed it using sed (I couldn't do it entirely with awk, yet I fought!).
